### PR TITLE
feat: stage claims & resume with verdicts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -67,6 +67,14 @@ export default function Home() {
   const [pipelineRuns, setPipelineRuns] = useState<PipelineRun[]>([])
   const [systemHealth, setSystemHealth] = useState<SystemHealth | null>(null)
   const [hasNewRun, setHasNewRun] = useState(false)
+  const [pendingRun, setPendingRun] = useState<{ uploadedAt: string } | null>(null)
+
+  useEffect(() => {
+    authFetch('/api/pending-run')
+      .then(r => r.json())
+      .then(data => setPendingRun(data.pendingRun))
+      .catch(() => { })
+  }, [])
 
   // Fetch system health
   useEffect(() => {
@@ -246,6 +254,33 @@ export default function Home() {
     })
     setStatus({ running: false, status: "idle", error: null, steps: [] })
     setActiveTab("upload")
+  }
+
+  const handleSaveClaims = async () => {
+    if (!files.claimsME && !files.claimsM2) {
+      alert('Please upload at least one claims file')
+      return
+    }
+    setLoading(true)
+    const formData = new FormData()
+    if (files.claimsME) formData.append('claims_matter_entertainment', files.claimsME)
+    if (files.claimsM2) formData.append('claims_matter_2', files.claimsM2)
+    try {
+      const response = await authFetch('/api/pending-run', { method: 'POST', body: formData })
+      if (!response.ok) throw new Error((await response.json()).error)
+      setPendingRun({ uploadedAt: new Date().toISOString() })
+      handleReset()
+    } catch (err) {
+      alert(`Failed to save claims: ${err instanceof Error ? err.message : err}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleClearPendingRun = async () => {
+    if (!confirm('Clear staged claims?')) return
+    await authFetch('/api/pending-run', { method: 'DELETE' })
+    setPendingRun(null)
   }
 
   const handleRetry = async (runId: string) => {
@@ -457,9 +492,12 @@ export default function Home() {
             files={files}
             isRunning={isRunning}
             loading={loading}
+            pendingRun={pendingRun}
             handleFileDrop={handleFileDrop}
             handleFileRemove={handleFileRemove}
             handleRunPipeline={handleRunPipeline}
+            handleSaveClaims={handleSaveClaims}
+            handleClearPendingRun={handleClearPendingRun}
             handleReset={handleReset}
           />
         )}

--- a/src/components/UploadTab/UploadTab.tsx
+++ b/src/components/UploadTab/UploadTab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { PlayCircle, Pause } from "lucide-react"
+import { PlayCircle, Pause, Save, AlertTriangle, Trash2 } from "lucide-react"
 
 import FileUpload from "@/components/FileUpload"
 import { formatRunFiles } from "@/utils/formatFiles"
@@ -16,9 +16,12 @@ interface UploadTabProps {
   files: FileState
   isRunning: boolean
   loading: boolean
+  pendingRun: { uploadedAt: string } | null
   handleFileDrop: (acceptedFiles: File[], fileType: keyof FileState) => void
   handleFileRemove: (fileType: keyof FileState) => void
   handleRunPipeline: () => void
+  handleSaveClaims: () => void
+  handleClearPendingRun: () => void
   handleReset: () => void
 }
 
@@ -26,9 +29,12 @@ export default function UploadTab({
   files,
   isRunning,
   loading,
+  pendingRun,
   handleFileDrop,
   handleFileRemove,
   handleRunPipeline,
+  handleSaveClaims,
+  handleClearPendingRun,
   handleReset,
 }: UploadTabProps) {
   const hasFiles =
@@ -36,6 +42,24 @@ export default function UploadTab({
 
   return (
     <div className="space-y-8">
+      {pendingRun && (
+        <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <AlertTriangle className="w-5 h-5 text-amber-500 flex-shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-amber-900">Claims staged — awaiting verdicts</p>
+              <p className="text-xs text-amber-700">Uploaded {new Date(pendingRun.uploadedAt).toLocaleString()}</p>
+            </div>
+          </div>
+          <button
+            onClick={handleClearPendingRun}
+            className="flex items-center gap-1 px-3 py-1.5 text-xs text-amber-700 hover:bg-amber-100 rounded-lg border border-amber-200 transition-colors"
+          >
+            <Trash2 className="w-3 h-3" />
+            Clear
+          </button>
+        </div>
+      )}
       <div className="text-center">
         <h2 className="text-3xl font-bold text-gray-900 mb-4">
           Process YouTube MCN Claims
@@ -114,7 +138,16 @@ export default function UploadTab({
         >
           Reset Files
         </button>
-
+        {(files.claimsME || files.claimsM2) && !files.mcnVerdicts && !files.jfmVerdicts && (
+          <button
+            onClick={handleSaveClaims}
+            disabled={isRunning || loading}
+            className="px-8 py-3 bg-amber-500 text-white rounded-xl font-medium hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+          >
+            <Save className="w-5 h-5" />
+            Save & Wait for Verdicts
+          </button>
+        )}
         <button
           onClick={handleRunPipeline}
           disabled={isRunning || !hasFiles}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Staged claims workflow: users can now save claims files and wait for verdict files later
  * Visual alert with upload timestamp displays when claims are staged
  * New "Save & Wait for Verdicts" button enables flexible, multi-step upload process
  * Option to clear staged claims with confirmation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JesusFilm/ytdt-claims-console/pull/20)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->