### PR TITLE
feat(upload): score pending claims without uploading files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ next-env.d.ts
 
 # pnpm
 .pnpm-store
+# editor
+.vscode/

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -259,6 +259,40 @@ export default function Home() {
     }
   }
 
+  // Score claims already awaiting a decision, without uploading anything.
+  // Exports whatever is currently unprocessed and runs the model over it,
+  // skipping the import and verdict steps.
+  const handleScorePending = async () => {
+    setLoading(true)
+    const formData = new FormData()
+    formData.append(
+      "steps",
+      "connect_vpn,export_views,enrich_ml,upload_drive"
+    )
+
+    try {
+      const response = await authFetch(`/api/run`, {
+        method: "POST",
+        body: formData,
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.error || `HTTP ${response.status}`)
+      }
+
+      setActiveTab("status")
+      setStatus({ running: true, status: "starting", error: null, steps: [] })
+    } catch (error) {
+      console.error("Score pending error:", error)
+      if (error instanceof Error) {
+        alert(`Failed to start scoring: ${error.message}`)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
   const handleReset = () => {
     setFiles({
       claimsME: null,
@@ -513,6 +547,7 @@ export default function Home() {
             handleFileDrop={handleFileDrop}
             handleFileRemove={handleFileRemove}
             handleRunPipeline={handleRunPipeline}
+            handleScorePending={handleScorePending}
             handleSaveClaims={handleSaveClaims}
             handleClearPendingRun={handleClearPendingRun}
             handleReset={handleReset}

--- a/src/components/UploadTab/UploadTab.test.tsx
+++ b/src/components/UploadTab/UploadTab.test.tsx
@@ -6,6 +6,9 @@ describe("UploadTab", () => {
   const mockHandleFileDrop = vi.fn()
   const mockHandleFileRemove = vi.fn()
   const mockHandleRunPipeline = vi.fn()
+  const mockHandleScorePending = vi.fn()
+  const mockHandleSaveClaims = vi.fn()
+  const mockHandleClearPendingRun = vi.fn()
   const mockHandleReset = vi.fn()
 
   const defaultProps = {
@@ -17,9 +20,13 @@ describe("UploadTab", () => {
     },
     isRunning: false,
     loading: false,
+    pendingRun: null,
     handleFileDrop: mockHandleFileDrop,
     handleFileRemove: mockHandleFileRemove,
     handleRunPipeline: mockHandleRunPipeline,
+    handleScorePending: mockHandleScorePending,
+    handleSaveClaims: mockHandleSaveClaims,
+    handleClearPendingRun: mockHandleClearPendingRun,
     handleReset: mockHandleReset,
   }
 
@@ -63,6 +70,35 @@ describe("UploadTab", () => {
     render(<UploadTab {...defaultProps} />)
     const runButton = screen.getByText("Run Pipeline")
     expect(runButton).toBeDisabled()
+  })
+
+  it("should offer scoring pending claims when no files are uploaded", () => {
+    render(<UploadTab {...defaultProps} />)
+    const scoreButton = screen.getByText("Score Pending Claims")
+    expect(scoreButton).toBeInTheDocument()
+    expect(scoreButton).not.toBeDisabled()
+  })
+
+  it("should call handleScorePending when score button is clicked", () => {
+    render(<UploadTab {...defaultProps} />)
+    fireEvent.click(screen.getByText("Score Pending Claims"))
+    expect(mockHandleScorePending).toHaveBeenCalledTimes(1)
+  })
+
+  it("should hide score button once files are uploaded", () => {
+    const file = new File(["content"], "test.csv", { type: "text/csv" })
+    render(
+      <UploadTab
+        {...defaultProps}
+        files={{ ...defaultProps.files, claimsME: file }}
+      />
+    )
+    expect(screen.queryByText("Score Pending Claims")).not.toBeInTheDocument()
+  })
+
+  it("should disable score button while a pipeline is running", () => {
+    render(<UploadTab {...defaultProps} isRunning={true} />)
+    expect(screen.getByText("Score Pending Claims")).toBeDisabled()
   })
 
   it("should enable run button when files are uploaded", () => {

--- a/src/components/UploadTab/UploadTab.tsx
+++ b/src/components/UploadTab/UploadTab.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { PlayCircle, Pause, Save, AlertTriangle, Trash2 } from "lucide-react"
+import {
+  PlayCircle,
+  Pause,
+  Save,
+  AlertTriangle,
+  Trash2,
+  Sparkles,
+} from "lucide-react"
 
 import FileUpload from "@/components/FileUpload"
 import { formatRunFiles } from "@/utils/formatFiles"
@@ -20,6 +27,7 @@ interface UploadTabProps {
   handleFileDrop: (acceptedFiles: File[], fileType: keyof FileState) => void
   handleFileRemove: (fileType: keyof FileState) => void
   handleRunPipeline: () => void
+  handleScorePending?: () => void
   handleSaveClaims: () => void
   handleClearPendingRun: () => void
   handleReset: () => void
@@ -33,6 +41,7 @@ export default function UploadTab({
   handleFileDrop,
   handleFileRemove,
   handleRunPipeline,
+  handleScorePending,
   handleSaveClaims,
   handleClearPendingRun,
   handleReset,
@@ -146,6 +155,16 @@ export default function UploadTab({
           >
             <Save className="w-5 h-5" />
             Save & Wait for Verdicts
+          </button>
+        )}
+        {!hasFiles && handleScorePending && (
+          <button
+            onClick={handleScorePending}
+            disabled={isRunning || loading}
+            className="px-8 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+          >
+            <Sparkles className="w-5 h-5" />
+            Score Pending Claims
           </button>
         )}
         <button


### PR DESCRIPTION
The Run Pipeline button is gated on hasFiles, so re-scoring claims that are already awaiting a decision required uploading a file that would then be re-imported. The gate was purely client side -- /api/run never required files -- but there was no way to reach that path from the UI.

Adds a Score Pending Claims action, shown only when no files are staged so one primary action is offered at a time (matching how Save & Wait for Verdicts appears). It posts a steps filter instead of files, running export and scoring without the import steps.

Run Pipeline and its gate are unchanged.

Also completes defaultProps in the UploadTab test, which was missing three required props and produced type errors on every render call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Score Pending Claims” option when no files are selected.
  * Starting the scoring process automatically opens the status view and shows that processing is underway.
  * The action is unavailable while processing or loading.

* **Bug Fixes**
  * Added handling for errors that occur when starting pending-claim scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->